### PR TITLE
Fail when an object property name is invalid

### DIFF
--- a/jsv4.php
+++ b/jsv4.php
@@ -274,6 +274,11 @@ class Jsv4 {
 					}
 				}
 			}
+			foreach ($this->data as $key => &$subValue) {
+				if (isset($checkedProperties[$key]) == false){
+					$this->fail(JSV4_INVALID_TYPE, "/$key", "/$key", "Object has invalid key: {$key}");
+				}
+			}
 		}
 		if (isset($this->schema->additionalProperties)) {
 			$additionalProperties = $this->schema->additionalProperties;


### PR DESCRIPTION
All the other rules were enforced except when a name of an object does not respect the specs.

this is a copy of https://github.com/geraintluff/jsv4-php/pull/23 (by https://github.com/BTooLs )